### PR TITLE
Implementation of -j/--json CLI option (ofmt)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ CFLAGS ?= -O2
 CFLAGS += -W -Wall -Wshadow -Wstrict-prototypes -Wpointer-arith -Wcast-qual \
           -Wcast-align -Wwrite-strings -Wmissing-prototypes -Winline -Wundef
 
+# By default we include support for JSON output, can be overridden on
+# the command line
+WITH_JSON ?= 1
+
 # Let lseek and mmap support 64-bit wide offsets
 CFLAGS += -D_FILE_OFFSET_BITS=64
 
@@ -29,6 +33,11 @@ CFLAGS += -D_FILE_OFFSET_BITS=64
 
 # Pass linker flags here (can be set from environment too)
 LDFLAGS ?=
+
+ifeq ($(WITH_JSON),1)
+CFLAGS += -DWITH_JSON_C
+LDFLAGS += -ljson-c
+endif
 
 DESTDIR =
 prefix  = /usr/local

--- a/README
+++ b/README
@@ -49,6 +49,10 @@ both (but I am not aware of SPARC-based systems implementing SMBIOS).
 Compiling for an IA64 processor requires the memory alignment workaround,
 and it is enabled automatically.
 
+The dmidecode is built by default with support for machine readable
+JSON format. The json-c (https://github.com/json-c/json-c) is used.
+To disable this feature the dmidecode has to be built using:
+"WITH_JSON=0 make"
 
 ** DOCUMENTATION **
 

--- a/completion/dmidecode.bash
+++ b/completion/dmidecode.bash
@@ -50,6 +50,7 @@ _comp_cmd_dmidecode() {
 			--from-dump
 			--no-sysfs
 			--oem-string
+			--json
 			--version
 		' -- "$cur"))
 		return 0

--- a/dmidecode.c
+++ b/dmidecode.c
@@ -1010,6 +1010,15 @@ static const char *dmi_processor_family(const struct dmi_header *h, u16 ver)
 		{ 0x26F, "Multi-Core Loongson 3B 5xxx" },
 		{ 0x270, "Multi-Core Loongson 3C 5xxx" },
 		{ 0x271, "Multi-Core Loongson 3D 5xxx" },
+
+		{ 0x300, "Core 3" },
+		{ 0x301, "Core 5" },
+		{ 0x302, "Core 7" },
+		{ 0x303, "Core 9" },
+		{ 0x304, "Core Ultra 3" },
+		{ 0x305, "Core Ultra 5" },
+		{ 0x306, "Core Ultra 7" },
+		{ 0x307, "Core Ultra 9" },
 	};
 	/*
 	 * Note to developers: when adding entries to this list, check if

--- a/dmidecode.c
+++ b/dmidecode.c
@@ -1462,10 +1462,17 @@ static const char *dmi_processor_upgrade(u8 code)
 		"Socket BGA1190",
 		"Socket BGA4129",
 		"Socket LGA4710",
-		"Socket LGA7529" /* 0x50 */
+		"Socket LGA7529",
+		"Socket BGA1964",
+		"Socket BGA1792",
+		"Socket BGA2049",
+		"Socket BGA2551",
+		"Socket LGA1851",
+		"Socket BGA2114",
+		"Socket BGA2833" /* 0x57 */
 	};
 
-	if (code >= 0x01 && code <= 0x50)
+	if (code >= 0x01 && code <= 0x57)
 		return upgrade[code - 0x01];
 	return out_of_spec;
 }

--- a/dmidecode.c
+++ b/dmidecode.c
@@ -6234,7 +6234,16 @@ int main(int argc, char * const argv[])
 		goto exit_free;
 	}
 
+#ifdef WITH_JSON_C
+	if (opt.flags & FLAG_JSON)
+	{
+		set_output_format(OFMT_JSON);
+	} else {
+		set_output_format(OFMT_PLAIN_TEXT);
+	}
+#else
 	set_output_format(OFMT_PLAIN_TEXT);
+#endif
 
 	if (!(opt.flags & FLAG_QUIET))
 		pr_comment("dmidecode %s", VERSION);

--- a/dmidecode.c
+++ b/dmidecode.c
@@ -6234,6 +6234,8 @@ int main(int argc, char * const argv[])
 		goto exit_free;
 	}
 
+	set_output_format(OFMT_PLAIN_TEXT);
+
 	if (!(opt.flags & FLAG_QUIET))
 		pr_comment("dmidecode %s", VERSION);
 

--- a/dmidecode.c
+++ b/dmidecode.c
@@ -6245,6 +6245,8 @@ int main(int argc, char * const argv[])
 	set_output_format(OFMT_PLAIN_TEXT);
 #endif
 
+	pr_init();
+
 	if (!(opt.flags & FLAG_QUIET))
 		pr_comment("dmidecode %s", VERSION);
 
@@ -6401,6 +6403,8 @@ done:
 		pr_comment("No SMBIOS nor DMI entry point found, sorry.");
 
 	free(buf);
+
+	pr_finish();
 exit_free:
 	free(opt.type);
 

--- a/dmidecode.c
+++ b/dmidecode.c
@@ -4483,11 +4483,11 @@ static void dmi_decode(const struct dmi_header *h, u16 ver)
 			dmi_bios_rom_size(data[0x09], h->length < 0x1A ? 16 : WORD(data + 0x18));
 			pr_list_start("Characteristics", NULL);
 			dmi_bios_characteristics(QWORD(data + 0x0A));
-			pr_list_end();
 			if (h->length < 0x13) break;
 			dmi_bios_characteristics_x1(data[0x12]);
 			if (h->length < 0x14) break;
 			dmi_bios_characteristics_x2(data[0x13]);
+			pr_list_end();
 			if (h->length < 0x18) break;
 			if (data[0x14] != 0xFF && data[0x15] != 0xFF)
 				pr_attr("BIOS Revision", "%u.%u",

--- a/dmiopt.c
+++ b/dmiopt.c
@@ -389,6 +389,20 @@ int parse_command_line(int argc, char * const argv[])
 		return -1;
 	}
 
+#ifdef WITH_JSON_C
+	if ((opt.flags & FLAG_JSON) && (opt.flags & FLAG_QUIET))
+	{
+		fprintf(stderr, "Options --quiet/--string/--oem-string and --json are mutually exclusive\n");
+		return -1;
+	}
+
+	if ((opt.flags & FLAG_JSON) && (opt.flags & FLAG_DUMP_BIN))
+	{
+		fprintf(stderr, "Options --json and --dump-bin are mutually exclusive\n");
+		return -1;
+	}
+#endif
+
 	return 0;
 }
 

--- a/dmiopt.c
+++ b/dmiopt.c
@@ -266,7 +266,7 @@ int parse_command_line(int argc, char * const argv[])
 {
 	int option;
 	unsigned int i;
-	const char *optstring = "d:hqs:t:uH:V";
+	const char *optstring = "d:hqs:t:uH:jV";
 	struct option longopts[] = {
 		{ "dev-mem", required_argument, NULL, 'd' },
 		{ "help", no_argument, NULL, 'h' },
@@ -282,6 +282,7 @@ int parse_command_line(int argc, char * const argv[])
 		{ "no-sysfs", no_argument, NULL, 'S' },
 		{ "list-strings", no_argument, NULL, 'L' },
 		{ "list-types", no_argument, NULL, 'T' },
+		{ "json", no_argument, NULL, 'j' },
 		{ "version", no_argument, NULL, 'V' },
 		{ NULL, 0, NULL, 0 }
 	};
@@ -345,6 +346,9 @@ int parse_command_line(int argc, char * const argv[])
 					fprintf(stdout, "%s\n", opt_type_keyword[i].keyword);
 				opt.flags |= FLAG_LIST;
 				return 0;
+			case 'j':
+				opt.flags |= FLAG_JSON;
+				break;
 			case 'V':
 				opt.flags |= FLAG_VERSION;
 				break;
@@ -362,6 +366,14 @@ int parse_command_line(int argc, char * const argv[])
 				}
 				return -1;
 		}
+
+#ifndef WITH_JSON_C
+	if (opt.flags & FLAG_JSON)
+	{
+		fprintf(stderr, "Unable to use --json; dmidecode was built without JSON support\n");
+		return -1;
+	}
+#endif
 
 	/* Check for mutually exclusive output format options */
 	if ((opt.string != NULL) + (opt.type != NULL)
@@ -399,6 +411,9 @@ void print_help(void)
 		"     --from-dump FILE   Read the DMI data from a binary file\n"
 		"     --no-sysfs         Do not attempt to read DMI data from sysfs files\n"
 		"     --oem-string N     Only display the value of the given OEM string\n"
+#ifdef WITH_JSON_C
+		" -j, --json             Output information in JSON format\n"
+#endif
 		" -V, --version          Display the version and exit\n";
 
 	printf("%s", help);

--- a/dmiopt.h
+++ b/dmiopt.h
@@ -48,6 +48,7 @@ extern struct opt opt;
 #define FLAG_NO_SYSFS           (1 << 6)
 #define FLAG_NO_QUIRKS          (1 << 7)
 #define FLAG_LIST               (1 << 8)
+#define FLAG_JSON               (1 << 9)
 
 int parse_command_line(int argc, char * const argv[]);
 void print_help(void);

--- a/dmioutput.c
+++ b/dmioutput.c
@@ -20,8 +20,22 @@
  */
 
 #include <stdarg.h>
+#ifdef WITH_JSON_C
+#define _GNU_SOURCE
+#include <json-c/json.h>
+#endif
 #include <stdio.h>
 #include "dmioutput.h"
+
+static void pr_init_ptext(void)
+{
+	/* a no-op for text output */
+}
+
+static void pr_finish_ptext(void)
+{
+	/* a no-op for text output */
+}
 
 static void pr_comment_ptext(const char *format, va_list args)
 {
@@ -100,6 +114,8 @@ static void pr_struct_err_ptext(const char *format, va_list args)
 
 static struct ofmt ofmt_plain_text =
 {
+	.pr_init        = pr_init_ptext,
+	.pr_finish      = pr_finish_ptext,
 	.pr_comment     = pr_comment_ptext,
 	.pr_info        = pr_info_ptext,
 	.pr_handle      = pr_handle_ptext,
@@ -113,7 +129,167 @@ static struct ofmt ofmt_plain_text =
 	.pr_struct_err  = pr_struct_err_ptext,
 };
 
-struct ofmt *ofmt;
+#ifdef WITH_JSON_C
+
+static struct json_context json_context;
+
+static void pr_init_json(void)
+{
+	json_context.root = json_object_new_object();
+	json_context.records = json_object_new_array();
+}
+
+static void pr_finish_json(void)
+{
+	/* Add array of decoded entries */
+	json_object_object_add(json_context.root, "dmi_data", json_context.records);
+	/* Print json object to stdout */
+	printf("%s\n", json_object_to_json_string_ext(json_context.root, JSON_C_TO_STRING_PRETTY));
+	/* Free root JSON object */
+	json_object_put(json_context.root);
+}
+
+static void pr_comment_json(const char *format, va_list args)
+{
+	(void)format;
+	(void)args;
+}
+
+static void pr_info_json(const char *format, va_list args)
+{
+	(void)format;
+	(void)args;
+}
+
+static void pr_handle_json(const struct dmi_header *h)
+{
+	int ret;
+	char handle_str[7];
+
+	json_context.item = json_object_new_object();
+
+	sprintf(handle_str, "0x%04X", h->handle);
+	ret = json_object_object_add(
+		json_context.item,
+		"handle",
+		json_object_new_string(handle_str)
+		);
+	if (ret < 0)
+		fprintf(stderr, "Unable to add JSON object: '%d' with key: 'handle'\n", h->handle);
+
+	ret = json_object_object_add(json_context.item, "type", json_object_new_int(h->type));
+	if (ret < 0)
+		fprintf(stderr, "Unable to add JSON object: '%d' with key: 'type'\n", h->type);
+
+	ret = json_object_object_add(json_context.item, "length", json_object_new_int(h->length));
+	if (ret < 0)
+		fprintf(stderr, "Unable to add JSON object: '%d' with key: 'length'\n", h->length);
+
+	if (h->type == 126)
+	{
+		json_object_object_add(json_context.item, "active", json_object_new_boolean(0));
+	}
+	else
+	{
+		json_object_object_add(json_context.item, "active", json_object_new_boolean(1));
+	}
+}
+
+static void pr_handle_name_json(const char *format, va_list args)
+{
+	if (json_context.item)
+	{
+		char *str = NULL;
+		int ret;
+
+		ret = vasprintf(&str, format, args);
+		if (ret != -1)
+		{
+			ret = json_object_object_add(json_context.item, "description", json_object_new_string(str));
+			if (ret < 0)
+			{
+				fprintf(stderr, "Unable to add JSON object: '%s' with key: 'description'\n", str);
+			}
+			free(str);
+		}
+	}
+}
+
+static void pr_attr_json(const char *name, const char *format, va_list args)
+{
+	(void)name;
+	(void)format;
+	(void)args;
+}
+
+static void pr_subattr_json(const char *name, const char *format, va_list args)
+{
+	(void)name;
+	(void)format;
+	(void)args;
+}
+
+static void pr_list_start_json(const char *name, const char *format, va_list args)
+{
+	(void)name;
+	(void)format;
+	(void)args;
+}
+
+static void pr_list_item_json(const char *format, va_list args)
+{
+	(void)format;
+	(void)args;
+}
+
+static void pr_list_end_json(void)
+{
+}
+
+static void pr_sep_json(void)
+{
+	if (json_context.item)
+	{
+		json_object_array_add(json_context.records, json_context.item);
+		json_context.item = NULL;
+	}
+}
+
+static void pr_struct_err_json(const char *format, va_list args)
+{
+	(void)format;
+	(void)args;
+}
+
+static struct ofmt ofmt_json =
+{
+	.pr_init        = pr_init_json,
+	.pr_finish      = pr_finish_json,
+	.pr_comment     = pr_comment_json,
+	.pr_info        = pr_info_json,
+	.pr_handle      = pr_handle_json,
+	.pr_handle_name = pr_handle_name_json,
+	.pr_attr        = pr_attr_json,
+	.pr_subattr     = pr_subattr_json,
+	.pr_list_start  = pr_list_start_json,
+	.pr_list_item   = pr_list_item_json,
+	.pr_list_end    = pr_list_end_json,
+	.pr_sep         = pr_sep_json,
+	.pr_struct_err  = pr_struct_err_json,
+};
+#endif
+
+struct ofmt *ofmt = NULL;
+
+void pr_init(void)
+{
+	ofmt->pr_init();
+}
+
+void pr_finish(void)
+{
+	ofmt->pr_finish();
+}
 
 void pr_comment(const char *format, ...)
 {
@@ -207,6 +383,11 @@ void set_output_format(int ofmt_nr)
 {
 	switch (ofmt_nr)
 	{
+#ifdef WITH_JSON_C
+		case OFMT_JSON:
+			ofmt = &ofmt_json;
+			break;
+#endif
 		default:
 			ofmt = &ofmt_plain_text;
 		break;

--- a/dmioutput.c
+++ b/dmioutput.c
@@ -251,19 +251,42 @@ static void pr_subattr_json(const char *name, const char *format, va_list args)
 
 static void pr_list_start_json(const char *name, const char *format, va_list args)
 {
-	(void)name;
+	// All calls of pr_list_start() uses the format and args for number of items in
+	// the list. Such information is useless, when machine-readable output is used.
 	(void)format;
 	(void)args;
+
+	json_context.list = json_object_new_array();
+	json_object_object_add(json_context.values, name, json_context.list);
 }
 
 static void pr_list_item_json(const char *format, va_list args)
 {
-	(void)format;
-	(void)args;
+	char *str = NULL;
+	int ret;
+	if (json_context.list)
+	{
+		ret = vasprintf(&str, format, args);
+		if (ret != -1)
+		{
+			json_object_array_add(json_context.list, json_object_new_string(str));
+			free(str);
+		}
+	}
+	else
+	{
+		ret = vasprintf(&str, format, args);
+		if (ret != -1)
+		{
+			fprintf(stderr, "Unable to add JSON item '%s' to the non existing list\n", str);
+			free(str);
+		}
+	}
 }
 
 static void pr_list_end_json(void)
 {
+	json_context.list = NULL;
 }
 
 static void pr_sep_json(void)

--- a/dmioutput.c
+++ b/dmioutput.c
@@ -23,6 +23,8 @@
 #ifdef WITH_JSON_C
 #define _GNU_SOURCE
 #include <json-c/json.h>
+#include <string.h>
+#include <ctype.h>
 #endif
 #include <stdio.h>
 #include "dmioutput.h"
@@ -193,6 +195,11 @@ static void pr_handle_json(const struct dmi_header *h)
 	{
 		json_object_object_add(json_context.item, "active", json_object_new_boolean(1));
 	}
+
+	json_context.values = json_object_new_object();
+	ret = json_object_object_add(json_context.item, "values", json_context.values);
+	if (ret < 0)
+		fprintf(stderr, "Unable to add JSON object with key: 'values'\n");
 }
 
 static void pr_handle_name_json(const char *format, va_list args)
@@ -215,18 +222,31 @@ static void pr_handle_name_json(const char *format, va_list args)
 	}
 }
 
+static void attr_json(const char *name, const char *format, va_list args)
+{
+	char *str = NULL;
+	int ret;
+
+	ret = vasprintf(&str, format, args);
+	if (ret != -1)
+	{
+		ret = json_object_object_add(json_context.values, name, json_object_new_string(str));
+		if (ret < 0)
+			fprintf(stderr, "Unable to add JSON object: '%s' with key: '%s'\n", str, name);
+		free(str);
+	} else {
+		fprintf(stderr, "Unable to create JSON key from name: '%s' and format: '%s'\n", name, format);
+	}
+}
+
 static void pr_attr_json(const char *name, const char *format, va_list args)
 {
-	(void)name;
-	(void)format;
-	(void)args;
+	attr_json(name, format, args);
 }
 
 static void pr_subattr_json(const char *name, const char *format, va_list args)
 {
-	(void)name;
-	(void)format;
-	(void)args;
+	attr_json(name, format, args);
 }
 
 static void pr_list_start_json(const char *name, const char *format, va_list args)

--- a/dmioutput.h
+++ b/dmioutput.h
@@ -34,6 +34,9 @@ void pr_sep(void);
 void pr_struct_err(const char *format, ...);
 
 #define OFMT_PLAIN_TEXT                0
+#ifdef WITH_JSON_C
+#define OFMT_JSON                      1
+#endif
 
 struct ofmt
 {

--- a/dmioutput.h
+++ b/dmioutput.h
@@ -32,3 +32,24 @@ void pr_list_item(const char *format, ...);
 void pr_list_end(void);
 void pr_sep(void);
 void pr_struct_err(const char *format, ...);
+
+#define OFMT_PLAIN_TEXT                0
+
+struct ofmt
+{
+	void (*pr_comment)(const char *format, va_list args);
+	void (*pr_info)(const char *format, va_list args);
+	void (*pr_handle)(const struct dmi_header *h);
+	void (*pr_handle_name)(const char *format, va_list args);
+	void (*pr_attr)(const char *name, const char *format, va_list args);
+	void (*pr_subattr)(const char *name, const char *format, va_list args);
+	void (*pr_list_start)(const char *name, const char *format, va_list args);
+	void (*pr_list_item)(const char *format, va_list args);
+	void (*pr_list_end)(void);
+	void (*pr_sep)(void);
+	void (*pr_struct_err)(const char *format, va_list args);
+};
+
+extern struct ofmt *ofmt;
+
+void set_output_format(int ofmt);

--- a/dmioutput.h
+++ b/dmioutput.h
@@ -46,6 +46,7 @@ struct json_context {
 	json_object *records;
 	json_object *item;
 	json_object *values;
+	json_object *list;
 };
 #endif
 

--- a/dmioutput.h
+++ b/dmioutput.h
@@ -19,8 +19,13 @@
  *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
  */
 
+#ifdef WITH_JSON_C
+#include <json-c/json.h>
+#endif
 #include "dmidecode.h"
 
+void pr_init(void);
+void pr_finish(void);
 void pr_comment(const char *format, ...);
 void pr_info(const char *format, ...);
 void pr_handle(const struct dmi_header *h);
@@ -36,10 +41,18 @@ void pr_struct_err(const char *format, ...);
 #define OFMT_PLAIN_TEXT                0
 #ifdef WITH_JSON_C
 #define OFMT_JSON                      1
+struct json_context {
+	json_object *root;
+	json_object *records;
+	json_object *item;
+	json_object *values;
+};
 #endif
 
 struct ofmt
 {
+	void (*pr_init)(void);
+	void (*pr_finish)(void);
 	void (*pr_comment)(const char *format, va_list args);
 	void (*pr_info)(const char *format, va_list args);
 	void (*pr_handle)(const struct dmi_header *h);

--- a/man/dmidecode.8
+++ b/man/dmidecode.8
@@ -1,3 +1,5 @@
+'\" t
+.\" ** The above line should force tbl to be a preprocessor **
 .TH DMIDECODE 8 "February 2023" "dmidecode"
 .\"
 .SH NAME

--- a/man/dmidecode.8
+++ b/man/dmidecode.8
@@ -189,6 +189,10 @@ Only display the value of the \s-1OEM\s0 string number \fIN\fP. The first
 \s-1OEM\s0 string has number \fB1\fP. With special value \fBcount\fP, return the
 number of OEM strings instead.
 .TP
+.BR "-j" ", " "--json"
+Dump DMI data into JSON machine readable format. This CLI options is available,
+when dmidecode is build with support of json-c library.
+.TP
 .BR "-h" ", " "--help"
 Display usage information and exit
 .TP
@@ -200,6 +204,12 @@ Options
 .BR --type,
 .BR --dump-bin " and " --oem-string
 determine the output format and are mutually exclusive.
+.P
+Options
+.BR --quiet,
+.BR --string,
+.BR --oem-string " and " --json
+determine the output format and are also mutually exclusive.
 .P
 Please note in case of
 .B dmidecode


### PR DESCRIPTION
This is PR was reworked from original PR: https://github.com/jirihnidek/dmidecode/pull/2/ according review

This PR add support for `-j/--json` CLI option providing machine readable output to JSON document. Compilation of `dmidecode` optionally requires `json-c` library (the support is enabled by default now). When `--json` CLI option is used, then the output is written to `stdout` using JSON format. This could be useful, when other application tries to parse output of `dmidecode`. Parsing of output does not require some special tool like jc. The code was tested with valgrind and there should not be any memory leaks.

To build dmidecode without support for json-c run:

```
WITH_JSON=0 make
```

Other changes:

* It is not possible to use `--json` with some other CLI options like --dump-bin
* Some comments and info messages are not saved to output, when `--json` is used.
* Manual pages were updates
* README was updated
* Bash completion script was updated